### PR TITLE
fix: Adjusted .DropZone--hasChildren CSS class to fix child element

### DIFF
--- a/packages/core/components/DropZone/styles.module.css
+++ b/packages/core/components/DropZone/styles.module.css
@@ -49,6 +49,15 @@
   ) !important;
 }
 
+.DropZone--hasChildren {
+  margin-left: initial;
+  margin-right: initial;
+  height: initial;
+  outline-offset: initial;
+  width: initial;
+  min-height: 128px;
+}
+
 .DropZone-item {
   position: relative;
 }


### PR DESCRIPTION
This change addresses the issue where the layout was a flexbox that positioned the children, but due to the dropzone class modifying some CSS properties of those children, the child element was essentially not what it was supposed to be.

In this GIF, you can see a header that is actually supposed to be as small as it needs to be since it's a flexbox. However, the dropzone adds a width of 100%, causing the header to take up the entire space. This also makes it difficult to position it correctly in the editor since it's actually not 100%. This PR is an attempt to fix that. I quickly tested it on the demo and in my own project and haven't noticed any issues so far.
 
![msedge_VJBA6x96Cn](https://github.com/Copystrike/puck/assets/26123873/3deddcec-611d-4e2c-adcf-0126124b58c1)
